### PR TITLE
fix spaces in paths

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -534,6 +534,11 @@ void MainWindow::onRunButtonClicked() {
     // now invoke dakota, done via a python script in tool app dircetory
     //
 
+    // wrap paths with quotes:
+    pySCRIPT = "\"" + pySCRIPT + "\"";
+    tDirectory = "\"" + tDirectory + "\"";
+    tmpDirectory = "\"" + tmpDirectory + "\"";
+
     QProcess *proc = new QProcess();
 
 #ifdef Q_OS_WIN
@@ -673,6 +678,11 @@ void MainWindow::onRemoteRunButtonClicked(){
     //
     // now invoke dakota, done via a python script in tool app dircetory
     //
+
+    // wrap paths with quotes:
+    pySCRIPT = "\"" + pySCRIPT + "\"";
+    tDirectory = "\"" + tDirectory + "\"";
+    tmpDirectory = "\"" + tmpDirectory + "\"";
 
     QProcess *proc = new QProcess();
 #ifdef Q_OS_WIN

--- a/RemoteJobCreator.cpp
+++ b/RemoteJobCreator.cpp
@@ -151,6 +151,8 @@ RemoteJobCreator::pushButtonClicked(void)
     // upload directory under user & submit job
     //  NOTE: the job is actually submitted when the uploadDirectory returns
     pushButton->setEnabled(false);
+
+    directoryName.replace("\"","");
     emit uploadDirCall(directoryName, remoteHomeDirPath);
 }
 


### PR DESCRIPTION
If the paths of input file and postscript file contain spaces, the program will fail on both local machine and designsafe. This commit fixes this issue. Please also test on windows. 